### PR TITLE
use original alias definition in new alias for fish shell

### DIFF
--- a/ap.fish
+++ b/ap.fish
@@ -13,13 +13,19 @@ set -q AUTO_PAGER_CMDS_WITH_GRC; or set AUTO_PAGER_CMDS_WITH_GRC    \
     docker docker-compose docker-machine kubectl
 
 for _cmd in $AUTO_PAGER_CMDS $AUTO_PAGER_CMDS_EXTRA;
-    [ "$_cmd" ]; and alias $_cmd "ap $_cmd"
+    [ "$_cmd" ]; or continue
+    alias | string match -q --regex "^alias \Q$_cmd\E '(ap (grc )?)?(?<_alias>.*)'"
+    [ "$_alias" ]; or set _alias "$_cmd"
+    alias $_cmd "ap $_alias"
 end
 
 type -p grc >/dev/null; and set _grc "grc "
 
 for _cmd in $AUTO_PAGER_CMDS_WITH_GRC $AUTO_PAGER_CMDS_WITH_GRC_EXTRA;
-    [ "$_cmd" ]; and alias $_cmd "ap $_grc$_cmd"
+    [ "$_cmd" ]; or continue
+    alias | string match -q --regex "^alias \Q$_cmd\E '(ap (grc )?)?(?<_alias>.*)'"
+    [ "$_alias" ]; or set _alias "$_cmd"
+    alias $_cmd "ap $_grc$_alias"
 end
 
-set -e _cmd _grc
+set -e _alias _cmd _grc


### PR DESCRIPTION
notice the regex match is very slow.

```
$ time source ap.fish

________________________________________________________
Executed in    1.63 secs    fish         external
   usr time    1.37 secs    1.37 secs    0.00 micros
   sys time    0.51 secs    0.51 secs    0.00 micros
```